### PR TITLE
Trim down Dockerfile Size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+README.md
+*.json
+dashboard/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
 FROM docker.io/fedora:36
 
-RUN dnf install -y --nodocs git python3-pip jq gettext helm make && dnf clean all && rm -rf /var/cache/yum
-RUN pip3 install ansible google-auth google-oauth
-RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
-RUN mkdir -p /usr/local/gcloud \
-  && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
-  && /usr/local/gcloud/google-cloud-sdk/install.sh
-# Install kubectl
-RUN curl -LO https://dl.k8s.io/release/v1.24.0/bin/linux/amd64/kubectl
-RUN sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-# Copy in scaffolding project
-RUN mkdir -p /scaffolding
-RUN git clone http://github.com/jtaleric/scaffolding /scaffolding
-RUN git clone https://github.com/cloud-bulldozer/benchmark-comparison && cd benchmark-comparison && sudo python3 setup.py develop && cd && rm -rf benchmark-comparison/
-RUN pip3 cache purge
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+RUN dnf install -y --nodocs \
+    helm \
+    jq \
+    python3-pip && \
+  dnf clean all && \
+  pip3 install --no-cache-dir \
+    ansible-core \
+    google-auth \
+    requests
+RUN curl -LO https://dl.k8s.io/release/v1.24.0/bin/linux/amd64/kubectl && \
+  install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+RUN curl -sSL https://api.github.com/repos/cloud-bulldozer/benchmark-comparison/tarball | tar -xzf - -C /opt && \
+  export bc_dir=/opt/$(ls /opt | grep cloud-bulldozer-benchmark-comparison) && \
+  pip install $bc_dir && \
+  rm -rf $bc_dir
+RUN ansible-galaxy collection install \
+    community.general \
+    google.cloud
+
+COPY . /scaffolding

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM docker.io/fedora:36
 
 RUN dnf install -y --nodocs \
     helm \
-    jq \
     python3-pip && \
   dnf clean all && \
   pip3 install --no-cache-dir \

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Store this file within this directory. Whatever you name it, update `group_vars/
 
 ```yaml
 gke:
-  zone: "us-west2-a"
+  region: "us-west2-a"
   project: "cilium-perf"
   auth_kind: "serviceaccount"
   sa_file: "my_sa.json"
@@ -81,7 +81,7 @@ To modify the cilium install params
  cilium*               # Binary which we used to install Cilium
  starttime             # When the Automation started
  cluster_name          # Name of the cluster in the event we have to manually clean up
- zone                # zone we deployed in
+ region                # Region we deployed in
  platform              # What Platform, GKE, OpenShift
  project               # Project we built the cluster in
  kubeconfig

--- a/README.md
+++ b/README.md
@@ -5,9 +5,15 @@ Ansible Automation to bring up a Performance SUT for Cilium Performance testing
 
 ## GKE
 
-Pull the container image with all the necessary tools -- sorry about the size, happy to have someone reduce it
+Pull the container image with all the necessary tools
 
 `$ podman pull quay.io/jtaleric/scaffolding`
+
+One can also build the container image from the project root, however please note that any files
+(ie including service account credentials) within the project directory will be included into the
+image
+
+`$ podman build . -t scaffolding`
 
 Kick it
 
@@ -26,7 +32,7 @@ Store this file within this directory. Whatever you name it, update `group_vars/
 
 ```yaml
 gke:
-  region: "us-west2-a"
+  zone: "us-west2-a"
   project: "cilium-perf"
   auth_kind: "serviceaccount"
   sa_file: "my_sa.json"
@@ -75,7 +81,7 @@ To modify the cilium install params
  cilium*               # Binary which we used to install Cilium
  starttime             # When the Automation started
  cluster_name          # Name of the cluster in the event we have to manually clean up
- region                # Region we deployed in
+ zone                # zone we deployed in
  platform              # What Platform, GKE, OpenShift
  project               # Project we built the cluster in
  kubeconfig

--- a/roles/platform/files/get-kubeconfig.py
+++ b/roles/platform/files/get-kubeconfig.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Create kubeconfig from output of `google.cloud.gcp_container_cluster`
+
+Use `google-auth` module to get an OAuth bearer token for the given
+service account, which can then be passed to kubectl in order to
+authenticate to the cluster.
+
+The token does expire, however re-running this script will refresh
+the token when needed.
+
+References:
+* https://github.com/mie00/gke-kubeconfig
+* https://google-auth.readthedocs.io/en/master/user-guide.html
+
+Requires `google-auth` and `requests` to be installed.
+"""
+import argparse
+import json
+import logging
+import os
+import shlex
+import subprocess
+import sys
+import typing as t
+
+from google.auth.transport.requests import Request
+from google.oauth2 import service_account
+
+KUBECONFIG_TEMPLATE = """
+apiVersion: v1
+kind: Config
+clusters:
+- name: {cluster_name}
+  cluster:
+    server: https://{cluster_server}
+    certificate-authority-data: {cluster_ca}
+users:
+- name: my-gke-sa-user
+  user:
+    token: {user_token}
+contexts:
+- context:
+    cluster: {cluster_name}
+    user: my-gke-sa-user
+  name: {cluster_name}
+current-context: {cluster_name}
+"""
+GOOGLE_AUTH_API_BASE = "https://www.googleapis.com/auth/"
+
+
+def get_google_sa_token(path_to_sa: str) -> str:
+    """Use given service account private key to get token for k8s api server."""
+
+    credentials = service_account.Credentials.from_service_account_file(
+        path_to_sa,
+        scopes=[
+            GOOGLE_AUTH_API_BASE + scope
+            for scope in ("userinfo.email", "cloud-platform")
+        ],
+    )
+    credentials.refresh(Request())
+    return credentials.token
+
+
+def build_kubeconfig(
+    kubeconfig_template: str,
+    cluster_server: str,
+    cluster_name: str,
+    cluster_ca: str,
+    user_token: str,
+) -> str:
+    """Use the given arguments to build a kubeconfig."""
+
+    return kubeconfig_template.format(
+        cluster_name=cluster_name,
+        cluster_server=cluster_server,
+        cluster_ca=cluster_ca,
+        user_token=user_token,
+    )
+
+
+def get_kubeconfig_params_from_gcp_container_cluster_json(
+    gcp_container_cluster_json: str,
+) -> t.Dict[str, str]:
+    """Get params for `build_kubeconfig` from `gcp_container_cluster` results."""
+
+    results = json.loads(gcp_container_cluster_json)
+    return {
+        "cluster_ca": results["masterAuth"]["clusterCaCertificate"],
+        "cluster_name": results["name"],
+        "cluster_server": results["endpoint"],
+    }
+
+
+def run_kubectl_command(cmd: str) -> None:
+    """Run the given kubectl command, assuming `set_kubeconfig`."""
+
+    cmd = "kubectl " + cmd
+    logging.info("Running '%s'", cmd)
+    try:
+        result = subprocess.run(
+            shlex.split(cmd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=os.environ,
+            timeout=20,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as err:
+        logging.warning(
+            "Got error while running kubectl command '%s': %s, %s",
+            cmd,
+            err,
+            err.stdout.decode("utf-8"),
+        )
+        raise
+
+    logging.info("Result: %s", result.stdout.decode("utf-8"))
+
+
+def setup_logging() -> None:
+    """Configure global console logging."""
+
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s: %(message)s",
+        level=logging.INFO,
+        stream=sys.stdout,
+    )
+
+
+def create_argument_parser() -> argparse.ArgumentParser:
+    """Create argument parser for the script."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "gcp_ansible_json",
+        help="File path to output of google.cloud.gcp_container_cluster",
+    )
+    parser.add_argument(
+        "service_account_file", help="Path to private key of Google IAM service account"
+    )
+    parser.add_argument("kubeconfig_dest", help="Destination of kubeconfig")
+
+    return parser
+
+
+def main() -> None:
+    setup_logging()
+    parser = create_argument_parser()
+    args = parser.parse_args()
+
+    logging.info(
+        "Parsing through gcp_container_cluster json: %s",
+        args.gcp_ansible_json,
+    )
+    with open(args.gcp_ansible_json, "r") as gcp_ansible_json_file_handler:
+        gcp_ansible_json = gcp_ansible_json_file_handler.read()
+    kubeconfig_args = get_kubeconfig_params_from_gcp_container_cluster_json(
+        gcp_ansible_json
+    )
+
+    logging.info("Getting token for sa authentication")
+    user_token = get_google_sa_token(args.service_account_file)
+    kubeconfig_args["user_token"] = user_token
+
+    kubeconfig = build_kubeconfig(KUBECONFIG_TEMPLATE, **kubeconfig_args)
+    with open(args.kubeconfig_dest, "w") as kubeconfig_file_handler:
+        kubeconfig_file_handler.write(kubeconfig)
+    logging.info("Kubeconfig written to %s", args.kubeconfig_dest)
+
+    os.environ["KUBECONFIG"] = args.kubeconfig_dest
+    run_kubectl_command("config view")
+    run_kubectl_command("get nodes")
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/platform/tasks/gke.yml
+++ b/roles/platform/tasks/gke.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: Get current clouds
-  gcp_container_cluster_info:
-    location: "{{ gke['region'] }}"
+  google.cloud.gcp_container_cluster_info:
+    location: "{{ gke['zone'] }}"
     project: "{{ gke['project'] }}"
     auth_kind: "{{ gke['auth_kind'] }}"
     service_account_file: "{{ gke['sa_file'] }}"
@@ -47,6 +47,8 @@
 
   - set_fact:
       gke_cluster_name: "{{cluster_prefix}}-{{start_time}}"
+  - debug:
+      msg: GKE Cluster name {{ gke_cluster_name }}
 
   - name: Create GKE cluster
     google.cloud.gcp_container_cluster:
@@ -72,9 +74,14 @@
         - https://www.googleapis.com/auth/cloud-platform
       state: present
     register: cluster
+  
+  - name: Save cluster info to archive
+    copy:
+      content: "{{cluster}}"
+      dest: "{{archive_dir}}/cluster.json"
 
   - name: Create GKE node pool
-    gcp_container_node_pool:
+    google.cloud.gcp_container_node_pool:
       name: default
       initial_node_count: "{{ num_nodes | int}}"
       config:
@@ -98,13 +105,7 @@
 
   - name: Generate kubeconfig due to - https://github.com/ansible/ansible/issues/66096
     shell: |
-      export GOOGLE_APPLICATION_CREDENTIALS={{ gke['sa_file']}}
-      gcloud auth activate-service-account $(cat sa.json | jq .client_email|sed 's/"//g' ) --key-file=sa.json --project $(cat sa.json | jq .project_id|sed 's/"//g' )
-      export KUBECONFIG={{archive_dir}}/kubeconfig
-      gcloud config set project {{ gke['project'] }}
-      gcloud config set compute/zone {{ gke['region'] }}
-      gcloud auth activate-service-account --key-file {{ gke['sa_file'] }}
-      gcloud container clusters get-credentials {{ gke_cluster_name }}
+      python3 {{role_path}}/files/get-kubeconfig.py {{archive_dir}}/cluster.json {{gke['sa_file']}} {{archive_dir}}/kubeconfig
 
   - set_fact:
       kubeconfig: "{{archive_dir}}/kubeconfig"

--- a/roles/platform/tasks/gke.yml
+++ b/roles/platform/tasks/gke.yml
@@ -50,6 +50,15 @@
   - debug:
       msg: GKE Cluster name {{ gke_cluster_name }}
 
+  - name: Drop project in metadata
+    shell: |
+      mkdir -p {{archive_dir}}
+      echo {{gke['project']}} > {{archive_dir}}/project
+      echo gke > {{archive_dir}}/platform
+      echo {{gke['region']}} > {{archive_dir}}/region
+      echo {{gke_cluster_name}} > {{archive_dir}}/cluster_name
+      echo {{start_time}} > {{archive_dir}}/starttime
+
   - name: Create GKE cluster
     google.cloud.gcp_container_cluster:
       name: "{{ gke_cluster_name }}"
@@ -109,13 +118,5 @@
 
   - set_fact:
       kubeconfig: "{{archive_dir}}/kubeconfig"
-
-  - name: Drop project in metadata
-    shell: |
-      echo {{gke['project']}} > {{archive_dir}}/project
-      echo gke > {{archive_dir}}/platform
-      echo {{gke['region']}} > {{archive_dir}}/region
-      echo {{gke_cluster_name}} > {{archive_dir}}/cluster_name
-      echo {{start_time}} > {{archive_dir}}/starttime
 
   when: create

--- a/roles/platform/tasks/gke.yml
+++ b/roles/platform/tasks/gke.yml
@@ -2,7 +2,7 @@
 
 - name: Get current clouds
   google.cloud.gcp_container_cluster_info:
-    location: "{{ gke['zone'] }}"
+    location: "{{ gke['region'] }}"
     project: "{{ gke['project'] }}"
     auth_kind: "{{ gke['auth_kind'] }}"
     service_account_file: "{{ gke['sa_file'] }}"


### PR DESCRIPTION
This PR trims down the Dockerfile size from ~2GB to 554 MB by finding ways to remove large dependencies. The following dependencies are removed from the Dockerfile:

* `git`, by using the GitHub API to download other dependencies instead.
* `jq` and `gcloud`, by using a python script to generate a kubeconfig for provisioned GKE clusters.
* `ansible` python package, replaced `ansible-core`, which is a stripped down version. Collections are installed as-needed.

Additionally, I've modified the Dockerfile to use the project root on the local filesystem rather than cloning the scaffolding repository, in order to help facilitate testing local changes.